### PR TITLE
Added Pod Wrangler support

### DIFF
--- a/players/podwrangler.js
+++ b/players/podwrangler.js
@@ -1,5 +1,6 @@
 (function() {	
-	if (window.top == window && $('#jquery_jplayer_1').length === 1) {
+	var jplayer = $('#jquery_jplayer_1');
+	if (window.top == window && jplayer.length === 1) {
 	    window.addEventListener('load', function() {
 			var simplify = new Simplify();
 
@@ -17,11 +18,11 @@
 			{
 			    if (data["state"] == Simplify.PLAYBACK_STATE_PLAYING) { 
 			    	/* Play current song */ 
-			    	$('#jquery_jplayer_1').jPlayer("play")
+			    	jplayer.jPlayer("play")
 			    	simplify.setCurrentTrack({ 
 						author: "",
 						title: $('h3').text().replace(/[^a-zA-Z\d\s:]/g, ''),
-						length: $("#jquery_jplayer_1").data("jPlayer").status.duration,
+						length: jplayer.data("jPlayer").status.duration,
 						features : {
 						    "disable_previous_track" : true,        //Disables selection of previous track
 						    "disable_next_track" : true             //Disables selection of next track
@@ -30,36 +31,55 @@
 				}; 
 			    if (data["state"] == Simplify.PLAYBACK_STATE_PAUSED) { 
 			    	/* Pause current song */ 
-			    	$('#jquery_jplayer_1').jPlayer("pause")
+			    	jplayer.jPlayer("pause")
 				};
 			});
 			simplify.bindToVolumeRequest(function()
 			{
 			    //Extract volume and return its amount as an integer
-			    return 100 * $("#jquery_jplayer_1").data("jPlayer").options.volume;
+			    return 100 * jplayer.data("jPlayer").options.volume;
 			})
 			simplify.bindToTrackPositionRequest(function()
 			{
 			    //Extract track position and return its amount in seconds
-			    return parseInt($("#jquery_jplayer_1").data("jPlayer").status.currentTime);
+			    return parseInt(jplayer.data("jPlayer").status.currentTime);
 			})
 
 			simplify.bind(Simplify.MESSAGE_DID_CHANGE_VOLUME, function(data)
 			{
 			    //Change volume to data["amount"]
-			    $('#jquery_jplayer_1').jPlayer("volume", data.amount/100);
+			    jplayer.jPlayer("volume", data.amount/100);
 			});
 
 			simplify.bind(Simplify.MESSAGE_DID_CHANGE_TRACK_POSITION, function(data)
 			{
 			    //Seek track to data["amount"] seconds
-			    if ($("#jquery_jplayer_1").data("jPlayer").status.paused) {
-			    	$('#jquery_jplayer_1').jPlayer("pause", data.amount);
+			    if (jplayer.data("jPlayer").status.paused) {
+			    	jplayer.jPlayer("pause", data.amount);
 			    } else {
-			    	$('#jquery_jplayer_1').jPlayer("play", data.amount);
+			    	jplayer.jPlayer("play", data.amount);
 			    }
 			});
 			simplify.setNewPlaybackState(Simplify.PLAYBACK_STATE_PAUSED);
+
+			// Bind browser play event to tell simplify about it.
+			jplayer.bind($.jPlayer.event.play,function(e){
+				simplify.setNewPlaybackState(Simplify.PLAYBACK_STATE_PLAYING);
+				simplify.setCurrentTrack({ 
+						author: "",
+						title: $('h3').text().replace(/[^a-zA-Z\d\s:]/g, ''),
+						length: jplayer.data("jPlayer").status.duration,
+						features : {
+						    "disable_previous_track" : true,        //Disables selection of previous track
+						    "disable_next_track" : true             //Disables selection of next track
+					    }
+					});
+			});
+
+			// Bind browser pause event to tell simplify about it.
+			jplayer.bind($.jPlayer.event.pause,function(e){
+				simplify.setNewPlaybackState(Simplify.PLAYBACK_STATE_PAUSED);
+			});
 		});
 	}
 })();


### PR DESCRIPTION
I use Pod Wrangler's webapp hosted on feedwrangler.net to listen to podcasts.  The site uses the jquery jplayer, so this extension could pretty easily adapted to a number of websites.  All features of Simplify are supported, except for next/previous track because it doesn't really make sense for this site.  I'll make a corresponding PR for the simplify_web_suite.
