### PR TITLE
Fix gulp watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -230,7 +230,7 @@ gulp.task("watch", function()
 	var watcher = gulp.watch([path.join(config.skeletonDir, "**", "*.*"), 
 							  config.simplifyCoreScript, 
 							  path.join(config.playersDir, "*.js")], 
-							  gulp.parallel("build"));
+							  gulp.parallel("default"));
 
 	watcher.on("change", function(event)
 	{


### PR DESCRIPTION
Gulp was running a build task without arguments on watch callback which
was building an invalid manifst.json. This commit fixes this problem by
running a default task instead.