### PR TITLE
Permit port number when locating player script

### DIFF
--- a/skeleton/chrome/extensions.template.js
+++ b/skeleton/chrome/extensions.template.js
@@ -10,7 +10,7 @@ var scripts = {
 };
 
 //Checking if current site is listed
-if (scripts[location.host.replace("www.", "")] != null)
+if (scripts[location.hostname.replace("www.", "")] != null)
 {
 	//Core API injection
 	var core = document.createElement("script");


### PR DESCRIPTION
When browsing from a custom port number, player scripts can't be located. Be more forgiving by allowing the player script to load when browsing from any port on a matching hostname.